### PR TITLE
Get post ID from WP_Post object

### DIFF
--- a/admin/wp-dispensary-rest-api.php
+++ b/admin/wp-dispensary-rest-api.php
@@ -367,14 +367,14 @@ function slug_register_prices() {
  * Get Prices
  */
 function slug_get_prices( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Prices
  */
-function slug_update_prices( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+function slug_update_prices( $value, $post, $field_name ) {
+	return update_post_meta( $post->ID, $field_name, $value );
 }
 
 /**
@@ -408,14 +408,14 @@ function slug_register_concentrateprices() {
  * Get Prices
  */
 function slug_get_concentrateprices( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Prices
  */
 function slug_update_concentrateprices( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**
@@ -449,14 +449,14 @@ function slug_register_edibleinfo() {
  * Get Edible info
  */
 function slug_get_edibleinfo( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Edible info
  */
 function slug_update_edibleinfo( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**
@@ -490,14 +490,14 @@ function slug_register_prerollinfo() {
  * Get Pre-roll info
  */
 function slug_get_prerollinfo( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Pre-roll info
  */
 function slug_update_prerollinfo( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**
@@ -534,14 +534,14 @@ function slug_register_compounds() {
  * Get Compound info
  */
 function slug_get_compounds( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Compound info
  */
 function slug_update_compounds( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**
@@ -575,14 +575,14 @@ function slug_register_topicalinfo() {
  * Get Topical info
  */
 function slug_get_topicalinfo( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Topical info
  */
 function slug_update_topicalinfo( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**
@@ -616,14 +616,14 @@ function slug_register_growerinfo() {
  * Get Grower info
  */
 function slug_get_growerinfo( $object, $field_name, $request ) {
-	return get_post_meta( $object['id'], $field_name, true );
+	return get_post_meta( $object->ID, $field_name, true );
 }
 
 /**
  * Update Grower info
  */
 function slug_update_growerinfo( $value, $object, $field_name ) {
-	return update_post_meta( $object['id'], $field_name, $value );
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**

--- a/admin/wp-dispensary-rest-api.php
+++ b/admin/wp-dispensary-rest-api.php
@@ -373,8 +373,8 @@ function slug_get_prices( $object, $field_name, $request ) {
 /**
  * Update Prices
  */
-function slug_update_prices( $value, $post, $field_name ) {
-	return update_post_meta( $post->ID, $field_name, $value );
+function slug_update_prices( $value, $object, $field_name ) {
+	return update_post_meta( $object->ID, $field_name, $value );
 }
 
 /**


### PR DESCRIPTION
Whenever I was trying to create a new item with prices in WPDispensary via the WordPress REST API, I kept getting an error. I chased it down and found out that the `register_rest_field` callbacks that handle post pricing were using their `$object` param as if it were an array, but per [the WordPress spec](https://developer.wordpress.org/reference/functions/register_rest_field/) the param is actually "a model object, like WP_Post" (and in this case, given the object type it is registering for, a WP_Post *should* always be what is passed to that function).

I've updated the callbacks to grab the ID via the WP_Post class, instead of looking at it as an array.